### PR TITLE
Jts/1989 invite suggestions

### DIFF
--- a/src/components/views/dialogs/InviteDialog.tsx
+++ b/src/components/views/dialogs/InviteDialog.tsx
@@ -75,6 +75,7 @@ import { NonEmptyArray } from "../../../@types/common";
 import { SdkContextClass } from "../../../contexts/SDKContext";
 import { UserProfilesStore } from "../../../stores/UserProfilesStore";
 import { Key } from "../../../Keyboard";
+import SpaceStore from "../../../stores/spaces/SpaceStore";
 
 // we have a number of types defined from the Matrix spec which can't reasonably be altered here.
 /* eslint-disable camelcase */
@@ -425,10 +426,20 @@ export default class InviteDialog extends React.PureComponent<Props, IInviteDial
     private encryptionByDefault = false;
     private profilesStore: UserProfilesStore;
     private allowOnboardingFlag = false;
+    // Verji
+    private spaceMembers = [] as RoomMember[];
+    private spaceMemberIds = [] as string[];
+    // Verji End
 
     public constructor(props: Props) {
         super(props);
-
+        // Verji Start - generate a list of userId's which are members in currently active space
+        this.spaceMembers = SpaceStore.instance.activeSpaceRoom?.getJoinedMembers() ?? ([] as RoomMember[]);
+        this.spaceMembers.forEach((m) => {
+            console.log(m);
+            this.spaceMemberIds.push(m.userId);
+        });
+        // Verji end
         if (props.kind === InviteKind.Invite && !props.roomId) {
             throw new Error("When using InviteKind.Invite a roomId is required for an InviteDialog");
         } else if (props.kind === InviteKind.CallTransfer && !props.call) {
@@ -458,7 +469,7 @@ export default class InviteDialog extends React.PureComponent<Props, IInviteDial
             targetEmails: [], // Verji
             filterText: this.props.initialText || "",
             // Mutates alreadyInvited set so that buildSuggestions doesn't duplicate any users
-            recents: InviteDialog.buildRecents(excludedIds),
+            recents: InviteDialog.buildRecents(excludedIds, this.spaceMemberIds), //VERJI add param spaceMemberIds
             numRecentsShown: INITIAL_ROOMS_SHOWN,
             suggestions: this.buildSuggestions(excludedIds),
             numSuggestionsShown: INITIAL_ROOMS_SHOWN,
@@ -523,7 +534,8 @@ export default class InviteDialog extends React.PureComponent<Props, IInviteDial
         externals.forEach((id) => excludedTargetIds.add(id));
     }
 
-    public static buildRecents(excludedTargetIds: Set<string>): Result[] {
+    // VERJI added param activeSpaceMembers - used to fileter the recents based on membership in space
+    public static buildRecents(excludedTargetIds: Set<string>, activeSpaceMembers: string[]): Result[] {
         const rooms = DMRoomMap.shared().getUniqueRoomsWithIndividuals(); // map of userId => js-sdk Room
 
         // Also pull in all the rooms tagged as DefaultTagID.DM so we don't miss anything. Sometimes the
@@ -552,6 +564,15 @@ export default class InviteDialog extends React.PureComponent<Props, IInviteDial
                 logger.warn(`[Invite:Recents] Excluding ${userId} from recents`);
                 continue;
             }
+
+            // Verji Start - filter out users not in space
+            if (!activeSpaceMembers.includes(userId)) {
+                logger.warn(
+                    `[Invite:Recents] Excluding ${userId} from recents because, the user is not a space member`,
+                );
+                continue;
+            }
+            // Verji End
 
             const room = rooms[userId];
             const roomMember = room.getMember(userId);
@@ -587,7 +608,7 @@ export default class InviteDialog extends React.PureComponent<Props, IInviteDial
         }
         if (!recents) logger.warn("[Invite:Recents] No recents to suggest!");
 
-        // Sort the recents by last active to save us time later
+        // Sort the recents by last active to save us time latery
         recents.sort((a, b) => b.lastActive - a.lastActive);
 
         return recents;
@@ -603,6 +624,7 @@ export default class InviteDialog extends React.PureComponent<Props, IInviteDial
         return Object.values(memberScores)
             .map(({ member }) => member)
             .filter((member) => !excludedTargetIds.has(member.userId))
+            .filter((member) => this.spaceMemberIds.includes(member.userId)) // Verji - add another layer of filtering, to only include members which are a member of space
             .sort(memberComparator)
             .map((member) => ({ userId: member.userId, user: toMember(member) }));
     }

--- a/src/components/views/dialogs/InviteDialog.tsx
+++ b/src/components/views/dialogs/InviteDialog.tsx
@@ -608,7 +608,7 @@ export default class InviteDialog extends React.PureComponent<Props, IInviteDial
         }
         if (!recents) logger.warn("[Invite:Recents] No recents to suggest!");
 
-        // Sort the recents by last active to save us time latery
+        // Sort the recents by last active to save us time later
         recents.sort((a, b) => b.lastActive - a.lastActive);
 
         return recents;


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->
# Ensure suggestions in InviteDialog to only show members of the current space

This PR adds another layer of filtering of the "Recents" and "Sugested" lists

- Creates a list of userIds of the currently selected space 
- Uses the list to filter what is added or returned in buildRecents and buildSuggestions

Originally I think the plan was to clear the store on context switch (switching spaces) 
But as the InviteDialog builds the lists on render, and by creating a list of possible suggestions using members of all rooms available. I that could be more dificult. So instead i modified the buildRecents and buildSuggestions methods slightly. 


## Checklist

-   [ ] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [ ] Linter and other CI checks pass.
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md)).
