### PR TITLE
Jts/2006 improve search

### DIFF
--- a/src/components/views/dialogs/InviteDialog.tsx
+++ b/src/components/views/dialogs/InviteDialog.tsx
@@ -430,7 +430,7 @@ export default class InviteDialog extends React.PureComponent<Props, IInviteDial
     // Verji
     private spaceMembers = [] as RoomMember[];
     private spaceMemberIds = [] as string[];
-    private searchResults = [] as any
+    private searchResults = [] as any;
     // Verji End
 
     public constructor(props: Props) {
@@ -489,7 +489,7 @@ export default class InviteDialog extends React.PureComponent<Props, IInviteDial
 
     public componentDidMount(): void {
         /* VERJI START */
-        
+
         // Get singleton VerjiGrowthBook - if not available, one will be created.
         // const verjiGrowthbook: VerjiGrowthBook = VerjiGrowthBook.getInstance();
 
@@ -619,11 +619,8 @@ export default class InviteDialog extends React.PureComponent<Props, IInviteDial
         const cli = MatrixClientPeg.safeGet();
         const activityScores = buildActivityScores(cli);
 
-        let memberScores  = {} as {[userId: string]: { member: RoomMember;
-            score: number;
-            numRooms: number;
-        }}
-        if(SettingsStore.getValue(UIFeature.ShowRoomMembersInSuggestions)){
+        let memberScores = {} as { [userId: string]: { member: RoomMember; score: number; numRooms: number } };
+        if (SettingsStore.getValue(UIFeature.ShowRoomMembersInSuggestions)) {
             memberScores = buildMemberScores(cli);
         }
 
@@ -663,7 +660,7 @@ export default class InviteDialog extends React.PureComponent<Props, IInviteDial
                 )
                 .then(async (r) => {
                     this.setState({ busy: false });
-                    this.searchResults = r.results
+                    this.searchResults = r.results;
                     if (r.results.find((e) => e.user_id == this.state.filterText.trim())) {
                         foundUser = true;
                     }
@@ -681,17 +678,17 @@ export default class InviteDialog extends React.PureComponent<Props, IInviteDial
         if (foundUser == false) {
             // Look in other stores for user if search might have failed unexpectedly
             // VERJI - Add feature flag ShowRoomMembersInSuggestions, if false, only show searchResults, and Recents
-            let possibleMembers = []
-            if(SettingsStore.getValue(UIFeature.ShowRoomMembersInSuggestions)){
+            let possibleMembers = [];
+            if (SettingsStore.getValue(UIFeature.ShowRoomMembersInSuggestions)) {
                 possibleMembers = [
                     ...this.state.recents,
                     ...this.state.suggestions,
                     ...this.state.serverResultsMixin,
                     ...this.state.threepidResultsMixin,
-                    ...this.searchResults
+                    ...this.searchResults,
                 ];
-            }else{
-                possibleMembers = [...this.state.recents, ...this.searchResults]
+            } else {
+                possibleMembers = [...this.state.recents, ...this.searchResults];
             }
             const toAdd = [];
             const potentialAddresses = this.state.filterText

--- a/src/components/views/dialogs/InviteDialog.tsx
+++ b/src/components/views/dialogs/InviteDialog.tsx
@@ -627,7 +627,6 @@ export default class InviteDialog extends React.PureComponent<Props, IInviteDial
             memberScores = buildMemberScores(cli);
         }
 
-        console.log("[VERJI INVESTIGATION] - Buildings suggestions....")
         const memberComparator = compareMembers(activityScores, memberScores);
         return Object.values(memberScores)
             .map(({ member }) => member)
@@ -1018,7 +1017,6 @@ export default class InviteDialog extends React.PureComponent<Props, IInviteDial
                         user: new DirectoryMember(u),
                     })),
                 });
-                console.log("[VERJI INVESTIGATION] - serverResultsMixin: ", this.state.serverResultsMixin)
             })
             .catch((e) => {
                 logger.error("Error searching user directory:");
@@ -1356,7 +1354,6 @@ export default class InviteDialog extends React.PureComponent<Props, IInviteDial
         let priorityAdditionalMembers: Result[] = []; // Shows up before our own suggestions, higher quality
         let otherAdditionalMembers: Result[] = []; // Shows up after our own suggestions, lower quality
         const hasMixins = this.state.serverResultsMixin || this.state.threepidResultsMixin;
-        console.log("[VERJI INVESTIGATION] - hasMixins: ", hasMixins)
         if (this.state.filterText && hasMixins && kind === "suggestions") {
             // We don't want to duplicate members though, so just exclude anyone we've already seen.
             // The type of u is a pain to define but members of both mixins have the 'userId' property

--- a/src/components/views/dialogs/spotlight/SpotlightDialog.tsx
+++ b/src/components/views/dialogs/spotlight/SpotlightDialog.tsx
@@ -386,7 +386,9 @@ const SpotlightDialog: React.FC<IProps> = ({ initialText = "", initialFilter = n
                 userResults.push(result);
             }
         }
-        addUserResults(findVisibleRoomMembers(visibleRooms, cli), false);
+        if(SettingsStore.getValue(UIFeature.ShowRoomMembersInSuggestions)){
+            addUserResults(findVisibleRoomMembers(visibleRooms, cli), false);
+        }
         addUserResults(userDirectorySearchResults, true);
         if (profile) {
             addUserResults([new DirectoryMember(profile)], true);
@@ -428,7 +430,6 @@ const SpotlightDialog: React.FC<IProps> = ({ initialText = "", initialFilter = n
         if (trimmedQuery) {
             const lcQuery = trimmedQuery.toLowerCase();
             const normalizedQuery = normalize(trimmedQuery);
-
             possibleResults.forEach((entry) => {
                 if (isRoomResult(entry)) {
                     // If the room is a DM with a user that is part of the user directory search results,

--- a/src/components/views/dialogs/spotlight/SpotlightDialog.tsx
+++ b/src/components/views/dialogs/spotlight/SpotlightDialog.tsx
@@ -386,7 +386,7 @@ const SpotlightDialog: React.FC<IProps> = ({ initialText = "", initialFilter = n
                 userResults.push(result);
             }
         }
-        if(SettingsStore.getValue(UIFeature.ShowRoomMembersInSuggestions)){
+        if (SettingsStore.getValue(UIFeature.ShowRoomMembersInSuggestions)) {
             addUserResults(findVisibleRoomMembers(visibleRooms, cli), false);
         }
         addUserResults(userDirectorySearchResults, true);

--- a/src/settings/Settings.tsx
+++ b/src/settings/Settings.tsx
@@ -1511,6 +1511,10 @@ export const SETTINGS: { [setting: string]: ISetting } = {
         supportedLevels: LEVELS_UI_FEATURE,
         default: true,
     },
+    [UIFeature.ShowRoomMembersInSuggestions]: {
+        supportedLevels: LEVELS_UI_FEATURE,
+        default: true,
+    },
 
     // Electron-specific settings, they are stored by Electron and set/read over an IPC.
     // We store them over there are they are necessary to know before the renderer process launches.

--- a/src/settings/Settings.tsx
+++ b/src/settings/Settings.tsx
@@ -1515,6 +1515,10 @@ export const SETTINGS: { [setting: string]: ISetting } = {
         supportedLevels: LEVELS_UI_FEATURE,
         default: true,
     },
+    [UIFeature.ShowRecentsInSuggestions]: {
+        supportedLevels: LEVELS_UI_FEATURE,
+        default: true,
+    },
 
     // Electron-specific settings, they are stored by Electron and set/read over an IPC.
     // We store them over there are they are necessary to know before the renderer process launches.

--- a/src/settings/UIFeature.ts
+++ b/src/settings/UIFeature.ts
@@ -102,6 +102,7 @@ export const enum UIFeature {
     HelpShowMatrixDisclosurePolicyAndLinks = "UIFeature.helpShowMatrixDisclosurePolicyAndLinks",
     ShowInviteToSpaceFromPeoplePlus = "UIFeature.showInviteToSpaceFromPeoplePlus",
     SettingShowMessageSearch = "UIFeature.settingShowMessageSearch",
+    ShowRoomMembersInSuggestions = "UIFeature.showRoomMembersInSuggestions",
 }
 
 export enum UIComponent {

--- a/src/settings/UIFeature.ts
+++ b/src/settings/UIFeature.ts
@@ -103,6 +103,7 @@ export const enum UIFeature {
     ShowInviteToSpaceFromPeoplePlus = "UIFeature.showInviteToSpaceFromPeoplePlus",
     SettingShowMessageSearch = "UIFeature.settingShowMessageSearch",
     ShowRoomMembersInSuggestions = "UIFeature.showRoomMembersInSuggestions",
+    ShowRecentsInSuggestions = "UIFeature.showRecentsInSuggestions",
 }
 
 export enum UIComponent {

--- a/src/utils/SortMembers.ts
+++ b/src/utils/SortMembers.ts
@@ -103,8 +103,8 @@ interface IMemberScore {
 
 export function buildMemberScores(cli: MatrixClient): { [userId: string]: IMemberScore } {
     // VERJI - if feature flag is false, we don't need to calculate and build memberscores, and just return an empty map instead. Suggestions will be populated by searchResults instead
-    if(!SettingsStore.getValue(UIFeature.ShowRoomMembersInSuggestions)){
-        return {} as {[userId: string]: IMemberScore}
+    if (!SettingsStore.getValue(UIFeature.ShowRoomMembersInSuggestions)) {
+        return {} as { [userId: string]: IMemberScore };
     }
     const maxConsideredMembers = 200;
     const consideredRooms = joinedRooms(cli).filter((room) => room.getJoinedMemberCount() < maxConsideredMembers);
@@ -114,10 +114,10 @@ export function buildMemberScores(cli: MatrixClient): { [userId: string]: IMembe
         console.log("[SortMembers.ts] - Processing room:", room.roomId);
         console.log("[SortMembers.ts] - is this a space room?:", room.isSpaceRoom());
         // VERJI - A filter to exclude members from Space Rooms, not really necessary if featureflag showRoomMembersInSuggestions is false, but keeping it in case we want to "fine-tune" suggestions later
-        if(room.isSpaceRoom()){
+        if (room.isSpaceRoom()) {
             console.log("[SortMembers.ts] - skipping the room", room.roomId);
             console.log("[SortMembers.ts] - number of members excluded: ", room.getJoinedMemberCount());
-            return []
+            return [];
         }
 
         return room.getJoinedMembers().map((member) => ({ member, roomSize: room.getJoinedMemberCount() }));

--- a/src/utils/SortMembers.ts
+++ b/src/utils/SortMembers.ts
@@ -110,13 +110,13 @@ export function buildMemberScores(cli: MatrixClient): { [userId: string]: IMembe
     const consideredRooms = joinedRooms(cli).filter((room) => room.getJoinedMemberCount() < maxConsideredMembers);
 
     const memberPeerEntries = consideredRooms.flatMap((room) => {
-        // Log the roomId here
-        console.log("[VERJI INVESTIGATION] - Processing room:", room.roomId);
-        console.log("[VERJI INVESTIGATION] - is this a space room?:", room.isSpaceRoom());
+        // VERJI Log the roomId here
+        console.log("[SortMembers.ts] - Processing room:", room.roomId);
+        console.log("[SortMembers.ts] - is this a space room?:", room.isSpaceRoom());
         // VERJI - A filter to exclude members from Space Rooms, not really necessary if featureflag showRoomMembersInSuggestions is false, but keeping it in case we want to "fine-tune" suggestions later
         if(room.isSpaceRoom()){
-            console.log("[VERJI INVESTIGATION] - skipping the room", room.roomId);
-            console.log("[VERJI INVESTIGATION] - number of members excluded: ", room.getJoinedMemberCount());
+            console.log("[SortMembers.ts] - skipping the room", room.roomId);
+            console.log("[SortMembers.ts] - number of members excluded: ", room.getJoinedMemberCount());
             return []
         }
 

--- a/test/components/views/dialogs/InviteDialog-test.tsx
+++ b/test/components/views/dialogs/InviteDialog-test.tsx
@@ -21,6 +21,7 @@ import { RoomType, MatrixClient, MatrixError, Room } from "matrix-js-sdk/src/mat
 import { KnownMembership } from "matrix-js-sdk/src/types";
 import { sleep } from "matrix-js-sdk/src/utils";
 import { mocked, Mocked } from "jest-mock";
+
 import InviteDialog from "../../../../src/components/views/dialogs/InviteDialog";
 import { InviteKind } from "../../../../src/components/views/dialogs/InviteDialogTypes";
 import {
@@ -217,9 +218,7 @@ describe("InviteDialog", () => {
         beforeEach(() => {
             // Mock activeSpaceRoom to be an object with getJoinedMembers method
             const roomMock: Partial<Room> = {
-                getJoinedMembers: jest
-                    .fn()
-                    .mockReturnValue([mockSpaceMembers/* mock RoomMember[] */]),
+                getJoinedMembers: jest.fn().mockReturnValue([mockSpaceMembers /* mock RoomMember[] */]),
             };
             const mockBuildMembers = jest.spyOn(SortMembers, "buildMemberScores");
             mockBuildMembers.mockImplementation(() => {


### PR DESCRIPTION
## Ensure there are no UI leakage of memberinfo in searches in SpotLightDialog / InviteDialog
* Added a new feature flags: 
  * `showRoomMembersInSuggestions` 
    * `true` - Use Elements own suggestion logic, using all room memberships/space memberships as suggestions. 
    * `false` - exclude suggestions, and use mostly search results to populate Suggestions. 
  * `showRecentsInSuggestions`
    * `true` - User Element default logic for displaying "Recents" in InviteDialog
    * `false` - exclude "Recents" in invite dialog

* It should not worsen the security/privacy, as the filtered recents should only be users you already share a DM with
* If we don't allow "recents" I think we should consider create our own cache / some other solution
  * As it is bothersome to "have" to search, in order to select a member you wish to invite to a room.  

## Notes for later 
* Initially attempted to make the suggestions adhere to our business logic. 
  * Some code from these attempts still in effect, as a security fallback / future use (SortMembers.ts buildMemberScores
  *  Experimented with "building" a roomlist based on rooms tagged with "app.verji.tenant_nfo"
      * Was very ineffective because in order to check if a room has tag, we must call the async method `cli.getStateEvent()` which uses a synapse endpont to get the tag/info. Which will spam the server when iterating through all the rooms
      * A better solution would be to create a seperate endpoint to get the roomIds which are relevant in tenant for user. 
 
### While developing I also did extensive testing of the Business logic, our Custom User Search, and frontend to make sure the following: 
 
![image](https://github.com/user-attachments/assets/cc58279b-d320-406d-aa74-9358011bda38)

Some changes required in backend, usersearch in order to solve the discrepancies, from expected result. As we in frontend, "trust" the search results fully.  

