### PR TITLE
Metaspace Other rooms(MetaSpace.Orphans) now also affected by MetaSpace Featureflags

### DIFF
--- a/src/components/structures/LeftPanel.tsx
+++ b/src/components/structures/LeftPanel.tsx
@@ -17,6 +17,10 @@ limitations under the License.
 import * as React from "react";
 import { createRef } from "react";
 import classNames from "classnames";
+import {
+    CustomComponentLifecycle,
+    CustomComponentOpts,
+} from "@matrix-org/react-sdk-module-api/lib/lifecycles/CustomComponentLifecycle";
 
 import dis from "../../dispatcher/dispatcher";
 import { _t } from "../../languageHandler";
@@ -46,10 +50,6 @@ import PageType from "../../PageTypes";
 import { UserOnboardingButton } from "../views/user-onboarding/UserOnboardingButton";
 import SettingsStore from "../../settings/SettingsStore";
 import { ModuleRunner } from "../../modules/ModuleRunner";
-import {
-    CustomComponentLifecycle,
-    CustomComponentOpts,
-} from "@matrix-org/react-sdk-module-api/lib/lifecycles/CustomComponentLifecycle";
 
 interface IProps {
     isMinimized: boolean;
@@ -361,9 +361,12 @@ export default class LeftPanel extends React.Component<IProps, IState> {
             );
         }
 
-            const customNewsOpts = { CustomComponent: React.Fragment };
-            ModuleRunner.instance.invoke(CustomComponentLifecycle.NewsAndOperatingMessages, customNewsOpts as CustomComponentOpts);
-            return (
+        const customNewsOpts = { CustomComponent: React.Fragment };
+        ModuleRunner.instance.invoke(
+            CustomComponentLifecycle.NewsAndOperatingMessages,
+            customNewsOpts as CustomComponentOpts,
+        );
+        return (
             <div
                 className="mx_LeftPanel_filterContainer"
                 onFocus={this.onFocus}
@@ -374,7 +377,7 @@ export default class LeftPanel extends React.Component<IProps, IState> {
                 <RoomSearch isMinimized={this.props.isMinimized} />
 
                 {dialPadButton}
-                <customNewsOpts.CustomComponent/>
+                <customNewsOpts.CustomComponent />
                 {rightButton}
             </div>
         );

--- a/src/components/views/dialogs/InviteDialog.tsx
+++ b/src/components/views/dialogs/InviteDialog.tsx
@@ -537,8 +537,8 @@ export default class InviteDialog extends React.PureComponent<Props, IInviteDial
     // VERJI added param activeSpaceMembers - used to filter the recents based on membership in space
     public static buildRecents(excludedTargetIds: Set<string>, activeSpaceMembers: string[]): Result[] {
         // Verji - If we don't want to see the Recents-suggestions(featureflag), we just return an empty array
-        if(!SettingsStore.getValue(UIFeature.ShowRecentsInSuggestions)){
-            return [] as Result[]
+        if (!SettingsStore.getValue(UIFeature.ShowRecentsInSuggestions)) {
+            return [] as Result[];
         }
         const rooms = DMRoomMap.shared().getUniqueRoomsWithIndividuals(); // map of userId => js-sdk Room
 
@@ -688,11 +688,8 @@ export default class InviteDialog extends React.PureComponent<Props, IInviteDial
                     ...this.state.serverResultsMixin,
                     ...this.state.threepidResultsMixin,
                 ];
-            }
-            else if(SettingsStore.getValue(UIFeature.ShowRecentsInSuggestions)){
-                possibleMembers = [
-                    ...this.state.recents
-                ];
+            } else if (SettingsStore.getValue(UIFeature.ShowRecentsInSuggestions)) {
+                possibleMembers = [...this.state.recents];
             }
             const toAdd = [];
             const potentialAddresses = this.state.filterText

--- a/src/components/views/rooms/RoomList.tsx
+++ b/src/components/views/rooms/RoomList.tsx
@@ -128,6 +128,7 @@ const DmAuxButton: React.FC<IAuxButtonProps> = ({ tabIndex, dispatcher = default
             case MetaSpace.Home:
             case MetaSpace.Favourites:
             case MetaSpace.People:
+            case MetaSpace.Orphans:
                 showStartChatPlusMenuForMetaSpace = false;
                 break;
 
@@ -371,6 +372,7 @@ const UntaggedAuxButton: React.FC<IAuxButtonProps> = ({ tabIndex }) => {
             case MetaSpace.Home:
             case MetaSpace.Favourites:
             case MetaSpace.People:
+            case MetaSpace.Orphans:
                 ShowAddRoomPlusMenuForMetaSpace = false;
                 break;
 

--- a/src/components/views/rooms/RoomListHeader.tsx
+++ b/src/components/views/rooms/RoomListHeader.tsx
@@ -417,6 +417,7 @@ const RoomListHeader: React.FC<IProps> = ({ onVisibilityChange }) => {
             case MetaSpace.Home:
             case MetaSpace.Favourites:
             case MetaSpace.People:
+            case MetaSpace.Orphans:
                 showPlusMenuForMetaSpace = false;
                 break;
 


### PR DESCRIPTION

The metaspace "Other rooms" (MetaSpace.Orphans) UIFeature.ShowPlusMenuForMetaSpace, UIFeature.ShowStartChatPlusMenuForMetaSpace & UIFeature.ShowAddRoomPlusMenuForMetaSpace

![image](https://github.com/user-attachments/assets/bea29aa3-cdf8-45a0-a6d6-81d80eba01f9)

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [ ] Linter and other CI checks pass.
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md)).
