### PR TITLE
Jts/2345 open space settings

### DIFF
--- a/src/components/views/elements/RoomTopic.tsx
+++ b/src/components/views/elements/RoomTopic.tsx
@@ -101,13 +101,12 @@ export default function RoomTopic({ room, className, ...props }: IProps): JSX.El
                                 kind="primary_outline"
                                 onClick={() => {
                                     modal.close();
-                                  // VERJI - show space settings instead, if it is a "Space Room". 
-                                    if(room.isSpaceRoom()){                                      
-                                      showSpaceSettings(room)
-                                    }else {
-                                      dis.dispatch({ action: "open_room_settings"});
+                                    // VERJI - show space settings instead, if it is a "Space Room".
+                                    if (room.isSpaceRoom()) {
+                                        showSpaceSettings(room);
+                                    } else {
+                                        dis.dispatch({ action: "open_room_settings" });
                                     }
-
                                 }}
                             >
                                 {_t("room|edit_topic")}

--- a/src/components/views/elements/RoomTopic.tsx
+++ b/src/components/views/elements/RoomTopic.tsx
@@ -30,6 +30,7 @@ import MatrixClientContext from "../../../contexts/MatrixClientContext";
 import AccessibleButton from "./AccessibleButton";
 import { Linkify, topicToHtml } from "../../../HtmlUtils";
 import { tryTransformPermalinkToLocalHref } from "../../../utils/permalinks/Permalinks";
+import { showSpaceSettings } from "../../../utils/space";
 
 interface IProps extends React.HTMLProps<HTMLDivElement> {
     room: Room;
@@ -100,7 +101,13 @@ export default function RoomTopic({ room, className, ...props }: IProps): JSX.El
                                 kind="primary_outline"
                                 onClick={() => {
                                     modal.close();
-                                    dis.dispatch({ action: "open_room_settings" });
+                                  // VERJI - show space settings instead, if it is a "Space Room". 
+                                    if(room.isSpaceRoom()){                                      
+                                      showSpaceSettings(room)
+                                    }else {
+                                      dis.dispatch({ action: "open_room_settings"});
+                                    }
+
                                 }}
                             >
                                 {_t("room|edit_topic")}


### PR DESCRIPTION

Fixed bug:
- When you clicked "Edit topic", it always opened RoomSettings
  - Now we check if the room is a Space:
    - If it's a space, we open SpaceSettings
    - If it's a room, we open RoomSettings
