### PR TITLE
Apply versioning to the usercontent iframe

### DIFF
--- a/res/css/views/dialogs/_InviteNewMembersDialog.pcss
+++ b/res/css/views/dialogs/_InviteNewMembersDialog.pcss
@@ -72,10 +72,10 @@
     flex-direction: row;
     width: 100%;
     align-items: center;
-    // :last-child {
-        // margin-left: 20px;
-        // scale: 0.8;
-    // }
+    /* :last-child {
+        margin-left: 20px;
+        scale: 0.8;
+    } */
 }
 
 .vmx_invite_external_user_field {
@@ -126,11 +126,11 @@
     background-color: var(--quinary-content, #6f7882);
     color: var(--primary-content, #ffffff);
 }
-// .vmx_LanguageDropdown {
-//     max-width: fit-content;
-// 	min-width: 80px;
-//     height: 40px;
-// }
+/* .vmx_LanguageDropdown {
+    max-width: fit-content;
+    min-width: 80px;
+    height: 40px;
+} */
 .vmx_dialog_footer {
     display: flex;
     flex-direction: row;

--- a/src/components/views/messages/MFileBody.tsx
+++ b/src/components/views/messages/MFileBody.tsx
@@ -256,7 +256,11 @@ export default class MFileBody extends React.Component<IProps, IState> {
                 );
             }
 
-            const url = "usercontent/"; // XXX: this path should probably be passed from the skin
+            // VERJI START
+            // const url = "usercontent/"; // XXX: this path should probably be passed from the skin
+            // Use the client version to avoid caching issues with the iframe content
+            const url = `usercontent/?v=${process.env.VERSION}`; // XXX: this path should probably be passed from the skin
+            // VERJI END
 
             // If the attachment is encrypted then put the link inside an iframe.
             return (

--- a/src/utils/FileDownloader.ts
+++ b/src/utils/FileDownloader.ts
@@ -53,7 +53,11 @@ function getManagedIframe(): { iframe: HTMLIFrameElement; onLoadPromise: Promise
         managedIframe.onload = () => {
             resolve();
         };
-        managedIframe.src = "usercontent/"; // XXX: Should come from the skin
+        // VERJI START
+        // managedIframe.src = "usercontent/"; XXX: Should come from the skin
+        // Use the client version to avoid caching issues with the iframe content
+        managedIframe.src = `usercontent/?v=${process.env.VERSION}`;
+        // VERJI END
     });
 
     return { iframe: managedIframe, onLoadPromise };


### PR DESCRIPTION
Adresses "Stale bundle / usercontent.js 404 errors"

This PR is part of the solution for: 
[#2551 - Usercontent Caching Issue](https://dev.azure.com/rosbergas/VerjiKanban/_boards/board/t/VerjiKanban%20Team/Issues?workitem=2451)

The full investigation an analasys is documented in the discussion:
[Usercontent Caching Issue (usercontent.js, FileDownloader.ts, stale bundle hash)](https://github.com/orgs/verji/discussions/174)

In short:
- We apply version to the usercontent iframe generated by the FileDownloader
- This way the client will use the referenced iframe's cache, instead of an older versions cache