### PR TITLE
Brand default mobile app links and logo fallbacks as Verji

### DIFF
--- a/src/SdkConfig.ts
+++ b/src/SdkConfig.ts
@@ -68,10 +68,12 @@ export const DEFAULTS: DeepReadonly<IConfigOptions> = {
         logo: "vector-icons/1024.png",
         url: "https://element.io/download",
     },
+    // VERJI: Verji's own mobile apps instead of Element's. Verji is not published on F-Droid, so that link is
+    // disabled by default.
     mobile_builds: {
-        ios: "https://apps.apple.com/app/vector/id1083446067",
-        android: "https://play.google.com/store/apps/details?id=im.vector.app",
-        fdroid: "https://f-droid.org/repository/browse/?fdid=im.vector.app",
+        ios: "https://apps.apple.com/app/verji/id1558512305",
+        android: "https://play.google.com/store/apps/details?id=com.rosberg.verji",
+        fdroid: null,
     },
 };
 

--- a/src/components/structures/HomePage.tsx
+++ b/src/components/structures/HomePage.tsx
@@ -144,7 +144,7 @@ const HomePage: React.FC<IProps> = ({ justRegistered = false }) => {
         introSection = <UserWelcomeTop />;
     } else {
         const brandingConfig = SdkConfig.getObject("branding");
-        const logoUrl = brandingConfig?.get("auth_header_logo_url") ?? "themes/element/img/logos/element-logo.svg";
+        const logoUrl = brandingConfig?.get("auth_header_logo_url") ?? "vector-icons/300.png"; // VERJI: Verji icon fallback
 
         introSection = (
             <React.Fragment>

--- a/src/components/views/auth/Welcome.tsx
+++ b/src/components/views/auth/Welcome.tsx
@@ -45,7 +45,7 @@ export default class Welcome extends React.PureComponent<IProps> {
         if (!pageUrl) {
             // Fall back to default and replace $logoUrl in welcome.html
             const brandingConfig = SdkConfig.getObject("branding");
-            const logoUrl = brandingConfig?.get("auth_header_logo_url") ?? "themes/element/img/logos/element-logo.svg";
+            const logoUrl = brandingConfig?.get("auth_header_logo_url") ?? "vector-icons/300.png"; // VERJI: Verji icon fallback
             replaceMap["$logoUrl"] = logoUrl;
             pageUrl = "welcome.html";
         }

--- a/test/components/views/dialogs/AppDownloadDialog-test.tsx
+++ b/test/components/views/dialogs/AppDownloadDialog-test.tsx
@@ -25,26 +25,32 @@ describe("AppDownloadDialog", () => {
         SdkConfig.reset();
     });
 
-    it("should render with desktop, ios, android, fdroid buttons by default", () => {
+    // VERJI: the default mobile_builds now point at the Verji apps, and fdroid defaults to null
+    // because Verji is not published on F-Droid. The two tests below were previously written
+    // around Element's defaults, where F-Droid was present unless explicitly disabled.
+    it("should render with desktop, ios and android buttons by default", () => {
         const { asFragment } = render(<AppDownloadDialog onFinished={jest.fn()} />);
         expect(screen.queryByRole("button", { name: "Download Element Desktop" })).toBeInTheDocument();
         expect(screen.queryByRole("button", { name: "Download on the App Store" })).toBeInTheDocument();
         expect(screen.queryByRole("button", { name: "Get it on Google Play" })).toBeInTheDocument();
-        expect(screen.queryByRole("button", { name: "Get it on F-Droid" })).toBeInTheDocument();
+        expect(screen.queryByRole("button", { name: "Get it on F-Droid" })).not.toBeInTheDocument();
         expect(asFragment()).toMatchSnapshot();
     });
 
-    it("should allow disabling fdroid build", () => {
+    // VERJI: inverted from "should allow disabling fdroid build". F-Droid is off by default now,
+    // so the case worth covering is that a deployment can still switch it back on through config.
+    it("should allow enabling fdroid build", () => {
         SdkConfig.add({
             mobile_builds: {
-                fdroid: null,
+                // Verji does not publish to F-Droid; this only exercises the config path.
+                fdroid: "https://f-droid.org/packages/com.example.app",
             },
         } as ConfigOptions);
         const { asFragment } = render(<AppDownloadDialog onFinished={jest.fn()} />);
         expect(screen.queryByRole("button", { name: "Download Element Desktop" })).toBeInTheDocument();
         expect(screen.queryByRole("button", { name: "Download on the App Store" })).toBeInTheDocument();
         expect(screen.queryByRole("button", { name: "Get it on Google Play" })).toBeInTheDocument();
-        expect(screen.queryByRole("button", { name: "Get it on F-Droid" })).not.toBeInTheDocument();
+        expect(screen.queryByRole("button", { name: "Get it on F-Droid" })).toBeInTheDocument();
         expect(asFragment()).toMatchSnapshot();
     });
 
@@ -58,7 +64,8 @@ describe("AppDownloadDialog", () => {
         expect(screen.queryByRole("button", { name: "Download Element Desktop" })).not.toBeInTheDocument();
         expect(screen.queryByRole("button", { name: "Download on the App Store" })).toBeInTheDocument();
         expect(screen.queryByRole("button", { name: "Get it on Google Play" })).toBeInTheDocument();
-        expect(screen.queryByRole("button", { name: "Get it on F-Droid" })).toBeInTheDocument();
+        // VERJI: F-Droid is off by default now
+        expect(screen.queryByRole("button", { name: "Get it on F-Droid" })).not.toBeInTheDocument();
         expect(asFragment()).toMatchSnapshot();
     });
 

--- a/test/components/views/dialogs/__snapshots__/AppDownloadDialog-test.tsx.snap
+++ b/test/components/views/dialogs/__snapshots__/AppDownloadDialog-test.tsx.snap
@@ -66,7 +66,7 @@ exports[`AppDownloadDialog should allow disabling desktop build 1`] = `
           <a
             aria-label="Download on the App Store"
             class="mx_AccessibleButton"
-            href="https://apps.apple.com/app/vector/id1083446067"
+            href="https://apps.apple.com/app/verji/id1558512305"
             role="button"
             tabindex="0"
             target="_blank"
@@ -109,173 +109,7 @@ exports[`AppDownloadDialog should allow disabling desktop build 1`] = `
           <a
             aria-label="Get it on Google Play"
             class="mx_AccessibleButton"
-            href="https://play.google.com/store/apps/details?id=im.vector.app"
-            role="button"
-            tabindex="0"
-            target="_blank"
-          >
-            <div />
-          </a>
-          <a
-            aria-label="Get it on F-Droid"
-            class="mx_AccessibleButton"
-            href="https://f-droid.org/repository/browse/?fdid=im.vector.app"
-            role="button"
-            tabindex="0"
-            target="_blank"
-          >
-            <div />
-          </a>
-        </div>
-      </div>
-    </div>
-    <div
-      class="mx_AppDownloadDialog_legal"
-    >
-      <p>
-        App Store® and the Apple logo® are trademarks of Apple Inc.
-      </p>
-      <p>
-        Google Play and the Google Play logo are trademarks of Google LLC.
-      </p>
-    </div>
-  </div>
-  <div
-    data-focus-guard="true"
-    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-    tabindex="0"
-  />
-</DocumentFragment>
-`;
-
-exports[`AppDownloadDialog should allow disabling fdroid build 1`] = `
-<DocumentFragment>
-  <div
-    data-focus-guard="true"
-    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-    tabindex="0"
-  />
-  <div
-    aria-labelledby="mx_BaseDialog_title"
-    class="mx_AppDownloadDialog mx_Dialog_fixedWidth"
-    data-focus-lock-disabled="false"
-    role="dialog"
-  >
-    <div
-      class="mx_Dialog_header"
-    >
-      <h1
-        class="mx_Heading_h3 mx_Dialog_title"
-        id="mx_BaseDialog_title"
-      >
-        Download Element
-      </h1>
-    </div>
-    <div
-      aria-label="Close dialog"
-      class="mx_AccessibleButton mx_Dialog_cancelButton"
-      role="button"
-      tabindex="0"
-    />
-    <div
-      class="mx_AppDownloadDialog_desktop"
-    >
-      <h3
-        class="mx_Heading_h3"
-      >
-        Download Element Desktop
-      </h3>
-      <a
-        class="mx_AccessibleButton mx_AccessibleButton_hasKind mx_AccessibleButton_kind_primary"
-        href="https://element.io/download"
-        role="button"
-        tabindex="0"
-        target="_blank"
-      >
-        Download Element Desktop
-      </a>
-    </div>
-    <div
-      class="mx_AppDownloadDialog_mobile"
-    >
-      <div
-        class="mx_AppDownloadDialog_app"
-      >
-        <h3
-          class="mx_Heading_h3"
-        >
-          iOS
-        </h3>
-        <div
-          class="mx_QRCode"
-        >
-          <div
-            class="mx_Spinner"
-          >
-            <div
-              aria-label="Loading…"
-              class="mx_Spinner_icon"
-              data-testid="spinner"
-              role="progressbar"
-              style="width: 32px; height: 32px;"
-            />
-          </div>
-        </div>
-        <div
-          class="mx_AppDownloadDialog_info"
-        >
-           or 
-        </div>
-        <div
-          class="mx_AppDownloadDialog_links"
-        >
-          <a
-            aria-label="Download on the App Store"
-            class="mx_AccessibleButton"
-            href="https://apps.apple.com/app/vector/id1083446067"
-            role="button"
-            tabindex="0"
-            target="_blank"
-          >
-            <div />
-          </a>
-        </div>
-      </div>
-      <div
-        class="mx_AppDownloadDialog_app"
-      >
-        <h3
-          class="mx_Heading_h3"
-        >
-          Android
-        </h3>
-        <div
-          class="mx_QRCode"
-        >
-          <div
-            class="mx_Spinner"
-          >
-            <div
-              aria-label="Loading…"
-              class="mx_Spinner_icon"
-              data-testid="spinner"
-              role="progressbar"
-              style="width: 32px; height: 32px;"
-            />
-          </div>
-        </div>
-        <div
-          class="mx_AppDownloadDialog_info"
-        >
-           or 
-        </div>
-        <div
-          class="mx_AppDownloadDialog_links"
-        >
-          <a
-            aria-label="Get it on Google Play"
-            class="mx_AccessibleButton"
-            href="https://play.google.com/store/apps/details?id=im.vector.app"
+            href="https://play.google.com/store/apps/details?id=com.rosberg.verji"
             role="button"
             tabindex="0"
             target="_blank"
@@ -373,7 +207,7 @@ exports[`AppDownloadDialog should allow disabling mobile builds 1`] = `
 </DocumentFragment>
 `;
 
-exports[`AppDownloadDialog should render with desktop, ios, android, fdroid buttons by default 1`] = `
+exports[`AppDownloadDialog should allow enabling fdroid build 1`] = `
 <DocumentFragment>
   <div
     data-focus-guard="true"
@@ -457,7 +291,7 @@ exports[`AppDownloadDialog should render with desktop, ios, android, fdroid butt
           <a
             aria-label="Download on the App Store"
             class="mx_AccessibleButton"
-            href="https://apps.apple.com/app/vector/id1083446067"
+            href="https://apps.apple.com/app/verji/id1558512305"
             role="button"
             tabindex="0"
             target="_blank"
@@ -500,7 +334,7 @@ exports[`AppDownloadDialog should render with desktop, ios, android, fdroid butt
           <a
             aria-label="Get it on Google Play"
             class="mx_AccessibleButton"
-            href="https://play.google.com/store/apps/details?id=im.vector.app"
+            href="https://play.google.com/store/apps/details?id=com.rosberg.verji"
             role="button"
             tabindex="0"
             target="_blank"
@@ -510,7 +344,163 @@ exports[`AppDownloadDialog should render with desktop, ios, android, fdroid butt
           <a
             aria-label="Get it on F-Droid"
             class="mx_AccessibleButton"
-            href="https://f-droid.org/repository/browse/?fdid=im.vector.app"
+            href="https://f-droid.org/packages/com.example.app"
+            role="button"
+            tabindex="0"
+            target="_blank"
+          >
+            <div />
+          </a>
+        </div>
+      </div>
+    </div>
+    <div
+      class="mx_AppDownloadDialog_legal"
+    >
+      <p>
+        App Store® and the Apple logo® are trademarks of Apple Inc.
+      </p>
+      <p>
+        Google Play and the Google Play logo are trademarks of Google LLC.
+      </p>
+    </div>
+  </div>
+  <div
+    data-focus-guard="true"
+    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+    tabindex="0"
+  />
+</DocumentFragment>
+`;
+
+exports[`AppDownloadDialog should render with desktop, ios and android buttons by default 1`] = `
+<DocumentFragment>
+  <div
+    data-focus-guard="true"
+    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+    tabindex="0"
+  />
+  <div
+    aria-labelledby="mx_BaseDialog_title"
+    class="mx_AppDownloadDialog mx_Dialog_fixedWidth"
+    data-focus-lock-disabled="false"
+    role="dialog"
+  >
+    <div
+      class="mx_Dialog_header"
+    >
+      <h1
+        class="mx_Heading_h3 mx_Dialog_title"
+        id="mx_BaseDialog_title"
+      >
+        Download Element
+      </h1>
+    </div>
+    <div
+      aria-label="Close dialog"
+      class="mx_AccessibleButton mx_Dialog_cancelButton"
+      role="button"
+      tabindex="0"
+    />
+    <div
+      class="mx_AppDownloadDialog_desktop"
+    >
+      <h3
+        class="mx_Heading_h3"
+      >
+        Download Element Desktop
+      </h3>
+      <a
+        class="mx_AccessibleButton mx_AccessibleButton_hasKind mx_AccessibleButton_kind_primary"
+        href="https://element.io/download"
+        role="button"
+        tabindex="0"
+        target="_blank"
+      >
+        Download Element Desktop
+      </a>
+    </div>
+    <div
+      class="mx_AppDownloadDialog_mobile"
+    >
+      <div
+        class="mx_AppDownloadDialog_app"
+      >
+        <h3
+          class="mx_Heading_h3"
+        >
+          iOS
+        </h3>
+        <div
+          class="mx_QRCode"
+        >
+          <div
+            class="mx_Spinner"
+          >
+            <div
+              aria-label="Loading…"
+              class="mx_Spinner_icon"
+              data-testid="spinner"
+              role="progressbar"
+              style="width: 32px; height: 32px;"
+            />
+          </div>
+        </div>
+        <div
+          class="mx_AppDownloadDialog_info"
+        >
+           or 
+        </div>
+        <div
+          class="mx_AppDownloadDialog_links"
+        >
+          <a
+            aria-label="Download on the App Store"
+            class="mx_AccessibleButton"
+            href="https://apps.apple.com/app/verji/id1558512305"
+            role="button"
+            tabindex="0"
+            target="_blank"
+          >
+            <div />
+          </a>
+        </div>
+      </div>
+      <div
+        class="mx_AppDownloadDialog_app"
+      >
+        <h3
+          class="mx_Heading_h3"
+        >
+          Android
+        </h3>
+        <div
+          class="mx_QRCode"
+        >
+          <div
+            class="mx_Spinner"
+          >
+            <div
+              aria-label="Loading…"
+              class="mx_Spinner_icon"
+              data-testid="spinner"
+              role="progressbar"
+              style="width: 32px; height: 32px;"
+            />
+          </div>
+        </div>
+        <div
+          class="mx_AppDownloadDialog_info"
+        >
+           or 
+        </div>
+        <div
+          class="mx_AppDownloadDialog_links"
+        >
+          <a
+            aria-label="Get it on Google Play"
+            class="mx_AccessibleButton"
+            href="https://play.google.com/store/apps/details?id=com.rosberg.verji"
             role="button"
             tabindex="0"
             target="_blank"


### PR DESCRIPTION
- `mobile_builds` defaults now point at the Verji iOS app (App Store id1558512305) and Android app (com.rosberg.verji). F-Droid is disabled because Verji is not published there. These defaults feed AppDownloadDialog and element-web's CompatibilityView / mobile guide.
- Welcome page and HomePage fall back to the Verji icon instead of the Element logo when `branding.auth_header_logo_url` is not configured.

Part of the "Element" -> "Verji" branding cleanup (page title, link previews, mobile landing page) done in verji/element-web.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

